### PR TITLE
Added support to disable worlds

### DIFF
--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -102,11 +102,12 @@ public class SuperbVoteConfiguration {
         List<String> commands = section.getStringList("commands");
         VoteMessage broadcast = VoteMessages.from(section, "broadcast-message", true, false);
         VoteMessage playerMessage = VoteMessages.from(section, "player-message", true, false);
+        VoteMessage playerWrongWorldMessage = VoteMessages.from(section, "player-wrong-world-message", true, false);
 
         List<RewardMatcher> rewards = RewardMatchers.getMatchers(section.getConfigurationSection("if"));
         boolean cascade = section.getBoolean("allow-cascading");
 
-        return new VoteReward(name, rewards, commands, playerMessage, broadcast, cascade);
+        return new VoteReward(name, rewards, commands, playerMessage, playerWrongWorldMessage, broadcast, cascade);
     }
 
     public List<VoteReward> getBestRewards(Vote vote) {
@@ -143,6 +144,16 @@ public class SuperbVoteConfiguration {
 
     public boolean requirePlayersOnline() {
         return configuration.getBoolean("require-online", false);
+    }
+    
+    public boolean matchesDisabledWorld(String worldName) {
+        List<String> disabledWorlds = configuration.getStringList("disabled-worlds");
+        for (String world : disabledWorlds) {
+            if (world.equalsIgnoreCase(worldName)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static String replacePlaceholders(String text, Vote vote) {

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbPreVoteEvent.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbPreVoteEvent.java
@@ -33,6 +33,7 @@ public class SuperbPreVoteEvent extends Event {
     public enum Result {
         PROCESS_VOTE,
         QUEUE_VOTE,
+        QUEUE_VOTE_WRONG_WORLD,
         CANCEL
     }
 }

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/VoteReward.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/rewards/VoteReward.java
@@ -16,6 +16,7 @@ public class VoteReward {
     private final List<RewardMatcher> rewardMatchers;
     private final List<String> commands;
     private final VoteMessage playerMessage;
+    private final VoteMessage playerWrongWorldMessage;
     private final VoteMessage broadcastMessage;
     private final boolean cascade;
 
@@ -25,7 +26,19 @@ public class VoteReward {
             if (playerMessage != null && player == onlinePlayer && playerAnnounce) {
                 playerMessage.sendAsBroadcast(player, vote);
             }
-	    if (broadcastMessage != null && broadcast) {
+            if (broadcastMessage != null && broadcast) {
+                broadcastMessage.sendAsBroadcast(player, vote);
+            }
+        }
+    }
+
+    public void broadcastVoteWrongWorld(Vote vote, boolean playerAnnounce, boolean broadcast) {
+        Player onlinePlayer = Bukkit.getPlayer(vote.getUuid());
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            if (playerWrongWorldMessage != null && player == onlinePlayer && playerAnnounce) {
+                playerWrongWorldMessage.sendAsBroadcast(player, vote);
+            }
+            if (broadcastMessage != null && broadcast) {
                 broadcastMessage.sendAsBroadcast(player, vote);
             }
         }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -38,16 +38,22 @@ rewards:
     commands:
     - give %player% diamond 4
     player-message: "&aThanks for meeting nearly impossible conditions, you have been rewarded with 4 diamonds and $1000."
+    player-wrong-world-message: "&cThanks for voting for us on %service%, your vote will be processed when you are in an enabled world next time!"
     broadcast-message: "&a%player% got really lucky and was rewarded with 4 diamonds and $1000!"
   # Default rewards are defined by having no preconditions. Place it at the bottom of the config.
   - if: {}
     commands:
     - eco give %player% 1000
     player-message: "&aThanks for voting for us on %service%, you have been rewarded with $1000."
+    player-wrong-world-message: "&cThanks for voting for us on %service%, your vote will be processed when you are in an enabled World next time!"
     broadcast-message: "&a%player% has voted for us on %service% and was rewarded with $1000!"
 
 # Whether or not players need to be online to vote. If set, offline player votes are queued for when the player next logs in.
 require-online: true
+
+# If a player is located in one of this worlds, the votes will be queued until he is in an enabled world next time. Requires "require-online" to be set to work properly.
+disabled-worlds:
+  - world_nether
 
 # Broadcast settings:
 broadcast:


### PR DESCRIPTION
Added a way to disable some worlds for vote processing.

If a player is **online** and stands inside a disabled world, his vote will be queued instead of processed.
If the option **require-online** is set to **false**, this check is **not done** when a player is not online, because the world can't be checked.

But that's no problem, because disabling worlds only make sense when giving rewards like diamonds and the player stands inside a world that has a different inventory than the main world (as an example). In such cases **require-online** must be set to **true** to give the player the reward.

For each vote reward a new message **player-wrong-world-message** can be set and will be displayed to the player if he is in a disabled world. An example of this is also added to the default configuration.

I'm running this modification on my own server for some days and it seems to work fine. I've disabled vote processing in the event world, because it has no shared inventory with all other worlds.

If you like this, you can merge it 😄 

FYI: 0.4-SNAPSHOT seems to be broken due to some minor bugs. I've written this ahead of 0.3.4 and running it with this version. But you can also merge it into 0.4, there shouldn't be any merge conflicts as far as I've tested.