### PR TITLE
AntiSpam feature + disable queue feature

### DIFF
--- a/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
@@ -7,6 +7,7 @@ import io.minimum.minecraft.superbvote.signboard.TopPlayerSignFetcher;
 import io.minimum.minecraft.superbvote.signboard.TopPlayerSignListener;
 import io.minimum.minecraft.superbvote.signboard.TopPlayerSignStorage;
 import io.minimum.minecraft.superbvote.storage.QueuedVotesStorage;
+import io.minimum.minecraft.superbvote.storage.RecentVotesStorage;
 import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.BrokenNag;
 import io.minimum.minecraft.superbvote.util.SpigotUpdater;
@@ -30,6 +31,8 @@ public class SuperbVote extends JavaPlugin {
     private VoteStorage voteStorage;
     @Getter
     private QueuedVotesStorage queuedVotes;
+    @Getter
+    private RecentVotesStorage recentVotesStorage;
     @Getter
     private ScoreboardHandler scoreboardHandler;
     @Getter
@@ -59,6 +62,8 @@ public class SuperbVote extends JavaPlugin {
         } catch (IOException e) {
             throw new RuntimeException("Exception whilst initializing queued vote storage", e);
         }
+
+        recentVotesStorage = new RecentVotesStorage();
 
         scoreboardHandler = new ScoreboardHandler();
         voteServiceCooldown = new VoteServiceCooldown(getConfig().getInt("votes.cooldown-per-service", 3600));

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -153,6 +153,10 @@ public class SuperbVoteConfiguration {
         return configuration.getBoolean("require-online", false);
     }
 
+    public boolean shouldQueueVotes() {
+        return configuration.getBoolean("queue-votes", true);
+    }
+
     public static String replaceCommandPlaceholders(String text, Vote vote) {
         return text.replaceAll("%player%", vote.getName())
                 .replaceAll("%service%", vote.getServiceName())

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/RecentVotesStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/RecentVotesStorage.java
@@ -1,0 +1,25 @@
+package io.minimum.minecraft.superbvote.storage;
+
+import io.minimum.minecraft.superbvote.SuperbVote;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RecentVotesStorage {
+
+    private final Map<UUID, Instant> lastVotes = new ConcurrentHashMap<>(32, 0.75f, 2);
+
+    public boolean canBroadcast(UUID uuid) {
+        if (!SuperbVote.getPlugin().getConfig().getBoolean("broadcast.antispam.enabled")) return true;
+        Instant start = lastVotes.getOrDefault(uuid, Instant.MIN);
+        int antispamTime = SuperbVote.getPlugin().getConfig().getInt("broadcast.antispam.time", 120);
+        return Duration.between(start, Instant.now()).getSeconds() >= antispamTime;
+    }
+
+    public void updateLastVote(UUID uuid) {
+        lastVotes.put(uuid, Instant.now());
+    }
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -71,6 +71,12 @@ public class SuperbVoteListener implements Listener {
         }
 
         if (queue) {
+            if (!SuperbVote.getPlugin().getConfiguration().shouldQueueVotes()) {
+                SuperbVote.getPlugin().getLogger().log(Level.WARNING, "Ignoring vote from " + vote.getName() + " (service: " +
+                        vote.getServiceName() + ") because they aren't online.");
+                return;
+            }
+
             SuperbVote.getPlugin().getLogger().log(Level.INFO, "Queuing vote from " + vote.getName() + " to be run later");
             for (VoteReward reward : bestRewards) {
                 reward.broadcastVote(context, false, broadcast && SuperbVote.getPlugin().getConfig().getBoolean("broadcast.queued") && canBroadcast && !hideBroadcast);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -50,6 +50,10 @@ rewards:
 # Whether or not players need to be online to vote. If set, offline player votes are queued for when the player next logs in.
 require-online: true
 
+# Whether we should queue votes if players aren't online. Requires the above option to be set to true.
+# If this is disabled, the user won't get any rewards if they aren't online, even if they login afterwards.
+queue-votes: true
+
 # Broadcast settings:
 broadcast:
   # Should we broadcast votes at all?

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -61,6 +61,13 @@ broadcast:
   # Should we broadcast queued votes?
   queued: true
 
+  antispam:
+    # Should we add a minimum time in between global broadcasts to prevent spam in chat?
+    enabled: false
+
+    # How many seconds should be between broadcasts?
+    time: 120
+
 # Vote command.
 # See http://www.minecraftforum.net/forums/minecraft-discussion/redstone-discussion-and/351959-1-9-json-text-component-for-tellraw-title-books
 # and https://www.minecraftjson.com for json text format


### PR DESCRIPTION
- Added a feature which will display broadcasts only once within x seconds (120 by default & disabled by default)
- Added a permission to bypass the broadcast, `superbvote.bypassbroadcast`, so sneaky player's cant secretly vote for "vanished" staff
- Added a feature which won't queue a vote if the player is offline; in other words: the player must be online to receive their vote. (disabled by default)