### PR TITLE
Add streaks

### DIFF
--- a/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
@@ -77,6 +77,7 @@ public class SuperbVote extends JavaPlugin {
 
         getCommand("superbvote").setExecutor(new SuperbVoteCommand());
         getCommand("vote").setExecutor(configuration.getVoteCommand());
+        getCommand("votestreak").setExecutor(configuration.getVoteStreakCommand());
 
         getServer().getPluginManager().registerEvents(new SuperbVoteListener(), this);
         getServer().getPluginManager().registerEvents(new TopPlayerSignListener(), this);
@@ -125,6 +126,7 @@ public class SuperbVote extends JavaPlugin {
         voteServiceCooldown = new VoteServiceCooldown(getConfig().getInt("votes.cooldown-per-service", 3600));
         getServer().getScheduler().runTaskAsynchronously(this, getScoreboardHandler()::doPopulate);
         getCommand("vote").setExecutor(configuration.getVoteCommand());
+        getCommand("votestreak").setExecutor(configuration.getVoteStreakCommand());
 
         if (voteReminderTask != null) {
             voteReminderTask.cancel();

--- a/src/main/java/io/minimum/minecraft/superbvote/commands/CommonCommand.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/commands/CommonCommand.java
@@ -3,6 +3,8 @@ package io.minimum.minecraft.superbvote.commands;
 import io.minimum.minecraft.superbvote.SuperbVote;
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
 import io.minimum.minecraft.superbvote.configuration.message.VoteMessage;
+import io.minimum.minecraft.superbvote.storage.ExtendedVoteStorage;
+import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.BrokenNag;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Bukkit;
@@ -13,8 +15,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @RequiredArgsConstructor
-public class VoteCommand implements CommandExecutor {
+public class CommonCommand implements CommandExecutor {
     private final VoteMessage message;
+    private final boolean streakRelated;
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] strings) {
@@ -30,7 +33,8 @@ public class VoteCommand implements CommandExecutor {
         }
 
         Bukkit.getScheduler().runTaskAsynchronously(SuperbVote.getPlugin(), () -> {
-            MessageContext ctx = new MessageContext(null, SuperbVote.getPlugin().getVoteStorage().getVotes(player.getUniqueId()), player);
+            VoteStorage voteStorage = SuperbVote.getPlugin().getVoteStorage();
+            MessageContext ctx = new MessageContext(null, voteStorage.getVotes(player.getUniqueId()), voteStorage.getVoteStreakIfSupported(player.getUniqueId(), streakRelated), player);
             message.sendAsReminder(player, ctx);
         });
         return true;

--- a/src/main/java/io/minimum/minecraft/superbvote/commands/SuperbVoteCommand.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/commands/SuperbVoteCommand.java
@@ -148,7 +148,7 @@ public class SuperbVoteCommand implements CommandExecutor {
                                 String posStr = Integer.toString(from + i + 1);
                                 sender.sendMessage(config
                                         .getEntryText()
-                                        .getWithOfflinePlayer(sender, new MessageContext(null, leaderboard.get(i), null))
+                                        .getWithOfflinePlayer(sender, new MessageContext(null, leaderboard.get(i), null, null))
                                         .replaceAll("%num%", posStr));
                             }
                             int availablePages = SuperbVote.getPlugin().getVoteStorage().getPagesAvailable(c);

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/StreaksConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/StreaksConfiguration.java
@@ -1,0 +1,9 @@
+package io.minimum.minecraft.superbvote.configuration;
+
+import lombok.Data;
+
+@Data
+public class StreaksConfiguration {
+	private final boolean enabled, placeholdersEnabled;
+	private final int requirement;
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/MessageContext.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/MessageContext.java
@@ -2,6 +2,7 @@ package io.minimum.minecraft.superbvote.configuration.message;
 
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import io.minimum.minecraft.superbvote.votes.Vote;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
 import org.bukkit.OfflinePlayer;
 
 import java.util.Optional;
@@ -9,11 +10,13 @@ import java.util.Optional;
 public class MessageContext {
     private final Vote vote;
     private final PlayerVotes voteRecord;
+    private final VoteStreak streakRecord;
     private final OfflinePlayer player;
 
-    public MessageContext(Vote vote, PlayerVotes voteRecord, OfflinePlayer player) {
+    public MessageContext(Vote vote, PlayerVotes voteRecord, VoteStreak streakRecord, OfflinePlayer player) {
         this.vote = vote;
         this.voteRecord = voteRecord;
+        this.streakRecord = streakRecord;
         this.player = player;
     }
 
@@ -25,6 +28,10 @@ public class MessageContext {
         return voteRecord;
     }
 
+    public Optional<VoteStreak> getStreakRecord() {
+        return Optional.ofNullable(streakRecord);
+    }
+
     public Optional<OfflinePlayer> getPlayer() {
         return Optional.ofNullable(player);
     }
@@ -34,6 +41,7 @@ public class MessageContext {
         return "MessageContext{" +
                 "vote=" + vote +
                 ", voteRecord=" + voteRecord +
+                ", streakRecord=" + streakRecord +
                 ", player=" + player +
                 '}';
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/placeholder/SuperbVotePlaceholderProvider.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/placeholder/SuperbVotePlaceholderProvider.java
@@ -2,6 +2,7 @@ package io.minimum.minecraft.superbvote.configuration.message.placeholder;
 
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
 import io.minimum.minecraft.superbvote.votes.Vote;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
 
 public class SuperbVotePlaceholderProvider implements PlaceholderProvider {
     @Override
@@ -12,6 +13,12 @@ public class SuperbVotePlaceholderProvider implements PlaceholderProvider {
         if (context.getVote().isPresent()) {
             Vote vote = context.getVote().get();
             base = base.replace("%service%", vote.getServiceName());
+        }
+        if (context.getStreakRecord().isPresent()) {
+            VoteStreak voteStreak = context.getStreakRecord().get();
+            base = base.replace("%streak%", Integer.toString(voteStreak.getCount()))
+                    .replace("%streak_days%", Integer.toString(voteStreak.getDays()))
+                    .replace("%streak_today_services%", Integer.toString(voteStreak.getLastDayServices().size()));
         }
         return base;
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/signboard/TopPlayerSignUpdater.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/signboard/TopPlayerSignUpdater.java
@@ -58,7 +58,7 @@ public class TopPlayerSignUpdater implements Runnable {
                         PlainStringMessage m = SuperbVote.getPlugin().getConfiguration().getTopPlayerSignsConfiguration().getSignText().get(i);
                         PlayerVotes pv = top.get(sign.getPosition() - 1);
                         worldSign.setLine(i, m.getWithOfflinePlayer(null,
-                                new MessageContext(null, pv, null)).replace("%num%", Integer.toString(sign.getPosition())));
+                                new MessageContext(null, pv, null, null)).replace("%num%", Integer.toString(sign.getPosition())));
                     }
                     for (int i = lines; i < 4; i++) {
                         worldSign.setLine(i, "");

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/ExtendedVoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/ExtendedVoteStorage.java
@@ -1,0 +1,14 @@
+package io.minimum.minecraft.superbvote.storage;
+
+import io.minimum.minecraft.superbvote.util.PlayerVotes;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public interface ExtendedVoteStorage extends VoteStorage {
+	VoteStreak getVoteStreak(UUID player, boolean required);
+
+	List<Map.Entry<PlayerVotes, VoteStreak>> getAllPlayersAndStreaksWithNoVotesToday(List<UUID> onlinePlayers);
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/VoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/VoteStorage.java
@@ -2,6 +2,7 @@ package io.minimum.minecraft.superbvote.storage;
 
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import io.minimum.minecraft.superbvote.votes.Vote;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
 
 import java.util.List;
 import java.util.UUID;
@@ -18,6 +19,13 @@ public interface VoteStorage {
     void clearVotes();
 
     PlayerVotes getVotes(UUID player);
+
+    default VoteStreak getVoteStreakIfSupported(UUID player, boolean required) {
+        if (this instanceof ExtendedVoteStorage) {
+        	return ((ExtendedVoteStorage) this).getVoteStreak(player, required);
+        }
+        return null;
+    }
 
     List<PlayerVotes> getTopVoters(int amount, int page);
 

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/VoteReminder.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/VoteReminder.java
@@ -2,11 +2,14 @@ package io.minimum.minecraft.superbvote.votes;
 
 import io.minimum.minecraft.superbvote.SuperbVote;
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
+import io.minimum.minecraft.superbvote.storage.ExtendedVoteStorage;
+import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -14,12 +17,28 @@ public class VoteReminder implements Runnable {
     @Override
     public void run() {
         List<UUID> onlinePlayers = Bukkit.getOnlinePlayers().stream().filter(p -> p.hasPermission("superbvote.notify")).map(Player::getUniqueId).collect(Collectors.toList());
-        List<PlayerVotes> noVotes = SuperbVote.getPlugin().getVoteStorage().getAllPlayersWithNoVotesToday(onlinePlayers);
-        for (PlayerVotes pv : noVotes) {
-            Player player = Bukkit.getPlayer(pv.getUuid());
-            if (player != null) {
-                MessageContext context = new MessageContext(null, pv, player);
-                SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(player, context);
+
+        VoteStorage voteStorage = SuperbVote.getPlugin().getVoteStorage();
+        if (SuperbVote.getPlugin().getConfiguration().getStreaksConfiguration().isPlaceholdersEnabled() && voteStorage instanceof ExtendedVoteStorage) {
+            List<Map.Entry<PlayerVotes, VoteStreak>> noVotes = ((ExtendedVoteStorage) voteStorage).getAllPlayersAndStreaksWithNoVotesToday(onlinePlayers);
+            for (Map.Entry<PlayerVotes, VoteStreak> entry : noVotes) {
+                PlayerVotes pv = entry.getKey();
+                VoteStreak voteStreak = entry.getValue();
+
+                Player player = Bukkit.getPlayer(pv.getUuid());
+                if (player != null) {
+                    MessageContext context = new MessageContext(null, pv, voteStreak, player);
+                    SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(player, context);
+                }
+            }
+        } else {
+            List<PlayerVotes> noVotes = voteStorage.getAllPlayersWithNoVotesToday(onlinePlayers);
+            for (PlayerVotes pv : noVotes) {
+                Player player = Bukkit.getPlayer(pv.getUuid());
+                if (player != null) {
+                    MessageContext context = new MessageContext(null, pv, null, player);
+                    SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(player, context);
+                }
             }
         }
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/VoteStreak.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/VoteStreak.java
@@ -1,0 +1,13 @@
+package io.minimum.minecraft.superbvote.votes;
+
+import lombok.Data;
+
+import java.util.List;
+import java.util.UUID;
+
+@Data
+public class VoteStreak {
+	private final UUID uuid;
+	private final int count, days;
+	private final List<String> lastDayServices;
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,7 @@ storage:
     password: topsecret
     database: superbvote
     table: votes
+    streaks-table: streaks
     read-only: false
 
 # General vote configuration.
@@ -24,6 +25,25 @@ votes:
 
   # Whether or not to treat fake votes as real votes
   process-fake-votes: true
+
+# Streaks configuration
+# Important: Streaks does not support JSON storage
+streaks:
+  enabled: false
+  # Fetch streaks almost everywhere to enable %streak%, %streak_days%, and %streak_today_services% placeholders
+  # outside of streak-related commands
+  enable-placeholders: true
+
+  # How many votes per day should a player get to keep his streak
+  requirement: 1
+
+  command:
+    # note: will be disabled if streaks are disabled
+    enabled: true
+    use-json-text: false
+    text: |-
+      You currently hold a vote streak of %streak% (%streak_days% days), keep going!
+      You've voted on %streak_today_services% website(s) out of X today.
 
 # Rewards. This is the main section you will need to edit. Ordering is important.
 rewards:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,9 @@ commands:
     aliases: [sv]
   vote:
     description: SuperbVote vote command.
+  votestreak:
+    description: SuperbVote vote streak command.
+    aliases: [vstreak]
 permissions:
   superbvote.notify:
     default: true


### PR DESCRIPTION
Add vote streaks as an optional feature, supporting only MySQL for storage.
- Add command `/votestreak` that displays the current streak, configurable like the `/vote` command.
- 3 new placeholders (`%streak%`, `%streak_days%`, and `%streak_today_services%`). They can be disabled in non-required places to prevent useless loading of streaks.
- When a player vote, his streak increases and the day counter of the streak increase automatically.
- Service names are stored as "today services" and/or "last day services" (for db references) to be able to set a daily requirement of websites or just show on how many websites a player has voted on.

Days are based on the database's time.

Technical changes:
- Added a new database table
- Renamed VoteCommand.java to CommonCommand.java as it shares everything except a message and a boolean with the streak command.