### PR TITLE
Add vote streaks

### DIFF
--- a/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/SuperbVote.java
@@ -11,7 +11,6 @@ import io.minimum.minecraft.superbvote.storage.RecentVotesStorage;
 import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.BrokenNag;
 import io.minimum.minecraft.superbvote.util.SpigotUpdater;
-import io.minimum.minecraft.superbvote.util.cooldowns.CooldownHandler;
 import io.minimum.minecraft.superbvote.util.cooldowns.VoteServiceCooldown;
 import io.minimum.minecraft.superbvote.votes.SuperbVoteListener;
 import io.minimum.minecraft.superbvote.votes.VoteReminder;
@@ -77,6 +76,7 @@ public class SuperbVote extends JavaPlugin {
 
         getCommand("superbvote").setExecutor(new SuperbVoteCommand());
         getCommand("vote").setExecutor(configuration.getVoteCommand());
+        getCommand("votestreak").setExecutor(configuration.getVoteStreakCommand());
 
         getServer().getPluginManager().registerEvents(new SuperbVoteListener(), this);
         getServer().getPluginManager().registerEvents(new TopPlayerSignListener(), this);
@@ -125,6 +125,7 @@ public class SuperbVote extends JavaPlugin {
         voteServiceCooldown = new VoteServiceCooldown(getConfig().getInt("votes.cooldown-per-service", 3600));
         getServer().getScheduler().runTaskAsynchronously(this, getScoreboardHandler()::doPopulate);
         getCommand("vote").setExecutor(configuration.getVoteCommand());
+        getCommand("votestreak").setExecutor(configuration.getVoteStreakCommand());
 
         if (voteReminderTask != null) {
             voteReminderTask.cancel();

--- a/src/main/java/io/minimum/minecraft/superbvote/commands/CommonCommand.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/commands/CommonCommand.java
@@ -3,6 +3,8 @@ package io.minimum.minecraft.superbvote.commands;
 import io.minimum.minecraft.superbvote.SuperbVote;
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
 import io.minimum.minecraft.superbvote.configuration.message.VoteMessage;
+import io.minimum.minecraft.superbvote.storage.ExtendedVoteStorage;
+import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.BrokenNag;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.Bukkit;
@@ -13,8 +15,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 @RequiredArgsConstructor
-public class VoteCommand implements CommandExecutor {
+public class CommonCommand implements CommandExecutor {
     private final VoteMessage message;
+    private final boolean streakRelated;
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String s, String[] strings) {
@@ -30,7 +33,8 @@ public class VoteCommand implements CommandExecutor {
         }
 
         Bukkit.getScheduler().runTaskAsynchronously(SuperbVote.getPlugin(), () -> {
-            MessageContext ctx = new MessageContext(null, SuperbVote.getPlugin().getVoteStorage().getVotes(player.getUniqueId()), player);
+            VoteStorage voteStorage = SuperbVote.getPlugin().getVoteStorage();
+            MessageContext ctx = new MessageContext(null, voteStorage.getVotes(player.getUniqueId()), voteStorage.getVoteStreakIfSupported(player.getUniqueId(), streakRelated), player);
             message.sendAsReminder(player, ctx);
         });
         return true;

--- a/src/main/java/io/minimum/minecraft/superbvote/commands/SuperbVoteCommand.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/commands/SuperbVoteCommand.java
@@ -148,7 +148,7 @@ public class SuperbVoteCommand implements CommandExecutor {
                                 String posStr = Integer.toString(from + i + 1);
                                 sender.sendMessage(config
                                         .getEntryText()
-                                        .getWithOfflinePlayer(sender, new MessageContext(null, leaderboard.get(i), null))
+                                        .getWithOfflinePlayer(sender, new MessageContext(null, leaderboard.get(i), null, null))
                                         .replaceAll("%num%", posStr));
                             }
                             int availablePages = SuperbVote.getPlugin().getVoteStorage().getPagesAvailable(c);

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/StreaksConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/StreaksConfiguration.java
@@ -4,5 +4,5 @@ import lombok.Data;
 
 @Data
 public class StreaksConfiguration {
-	private final boolean enabled, placeholdersEnabled, sharedCooldownPerService;
+    private final boolean enabled, placeholdersEnabled, sharedCooldownPerService;
 }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/StreaksConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/StreaksConfiguration.java
@@ -1,0 +1,8 @@
+package io.minimum.minecraft.superbvote.configuration;
+
+import lombok.Data;
+
+@Data
+public class StreaksConfiguration {
+	private final boolean enabled, placeholdersEnabled, sharedCooldownPerService;
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/SuperbVoteConfiguration.java
@@ -5,7 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.pool.HikariPool;
 import io.minimum.minecraft.superbvote.SuperbVote;
-import io.minimum.minecraft.superbvote.commands.VoteCommand;
+import io.minimum.minecraft.superbvote.commands.CommonCommand;
 import io.minimum.minecraft.superbvote.configuration.message.OfflineVoteMessages;
 import io.minimum.minecraft.superbvote.configuration.message.PlainStringMessage;
 import io.minimum.minecraft.superbvote.configuration.message.VoteMessage;
@@ -16,7 +16,10 @@ import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import io.minimum.minecraft.superbvote.votes.Vote;
 import io.minimum.minecraft.superbvote.votes.rewards.VoteReward;
-import io.minimum.minecraft.superbvote.votes.rewards.matchers.*;
+import io.minimum.minecraft.superbvote.votes.rewards.matchers.RewardMatcher;
+import io.minimum.minecraft.superbvote.votes.rewards.matchers.RewardMatchers;
+import io.minimum.minecraft.superbvote.votes.rewards.matchers.StaticRewardMatcher;
+import lombok.AccessLevel;
 import lombok.Getter;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.MemoryConfiguration;
@@ -29,19 +32,20 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
+@Getter
 public class SuperbVoteConfiguration {
+    @Getter(AccessLevel.NONE)
     private final ConfigurationSection configuration;
-    @Getter
+
     private final List<VoteReward> rewards = new ArrayList<>();
-    @Getter
     private final VoteMessage reminderMessage;
-    @Getter
-    private final VoteCommand voteCommand;
-    @Getter
+    private final CommonCommand voteCommand, voteStreakCommand;
+
     private final TextLeaderboardConfiguration textLeaderboardConfiguration;
-    @Getter
     private final TopPlayerSignsConfiguration topPlayerSignsConfiguration;
-    @Getter
+
+    private final StreaksConfiguration streaksConfiguration;
+
     private boolean configurationError = false;
 
     private static final List<String> SUPPORTED_STORAGE = ImmutableList.of("json", "mysql");
@@ -100,9 +104,18 @@ public class SuperbVoteConfiguration {
         if (configuration.getBoolean("vote-command.enabled")) {
             boolean useJson = configuration.getBoolean("vote-command.use-json-text");
             VoteMessage voteMessage = VoteMessages.from(configuration, "vote-command.text", false, useJson);
-            voteCommand = new VoteCommand(voteMessage);
+            voteCommand = new CommonCommand(voteMessage, false);
         } else {
             voteCommand = null;
+        }
+
+        streaksConfiguration = initializeStreaksConfiguration();
+        if (streaksConfiguration.isEnabled() && configuration.getBoolean("streaks.command.enabled")) {
+            boolean useJson = configuration.getBoolean("streaks.command.use-json-text");
+            VoteMessage voteStreakMessage = VoteMessages.from(configuration, "streaks.command.text", false, useJson);
+            voteStreakCommand = new CommonCommand(voteStreakMessage, true);
+        } else {
+            voteStreakCommand = null;
         }
 
         textLeaderboardConfiguration = new TextLeaderboardConfiguration(
@@ -163,6 +176,18 @@ public class SuperbVoteConfiguration {
                 .replaceAll("%player_uuid%", vote.getUuid().toString());
     }
 
+    private StreaksConfiguration initializeStreaksConfiguration() {
+        ConfigurationSection section = configuration.getConfigurationSection("streaks");
+        if (section == null) {
+            return new StreaksConfiguration(false, false, false);
+        }
+
+        boolean enabled = section.getBoolean("enabled");
+        boolean placeholdersEnabled = section.getBoolean("enable-placeholders");
+        boolean sharedCooldownPerService = section.getBoolean("shared-cooldown-per-service");
+        return new StreaksConfiguration(enabled, enabled && placeholdersEnabled, enabled && sharedCooldownPerService);
+    }
+
     public VoteStorage initializeVoteStorage() throws IOException {
         String storage = configuration.getString("storage.database");
         if (!SUPPORTED_STORAGE.contains(storage)) {
@@ -185,6 +210,7 @@ public class SuperbVoteConfiguration {
                 String password = configuration.getString("storage.mysql.password", "");
                 String database = configuration.getString("storage.mysql.database", "superbvote");
                 String table = configuration.getString("storage.mysql.table", "superbvote");
+                String streaksTableName = configuration.getString("storage.mysql.streaks-table");
                 boolean readOnly = configuration.getBoolean("storage.mysql.read-only");
 
                 HikariConfig config = new HikariConfig();
@@ -194,7 +220,7 @@ public class SuperbVoteConfiguration {
                 config.setMinimumIdle(2);
                 config.setMaximumPoolSize(6);
                 HikariPool pool = new HikariPool(config);
-                MysqlVoteStorage mysqlVoteStorage = new MysqlVoteStorage(pool, table, readOnly);
+                MysqlVoteStorage mysqlVoteStorage = new MysqlVoteStorage(pool, table, streaksTableName, readOnly);
                 mysqlVoteStorage.initialize();
                 return mysqlVoteStorage;
         }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/MessageContext.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/MessageContext.java
@@ -2,6 +2,7 @@ package io.minimum.minecraft.superbvote.configuration.message;
 
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import io.minimum.minecraft.superbvote.votes.Vote;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
 import org.bukkit.OfflinePlayer;
 
 import java.util.Optional;
@@ -9,11 +10,13 @@ import java.util.Optional;
 public class MessageContext {
     private final Vote vote;
     private final PlayerVotes voteRecord;
+    private final VoteStreak streakRecord;
     private final OfflinePlayer player;
 
-    public MessageContext(Vote vote, PlayerVotes voteRecord, OfflinePlayer player) {
+    public MessageContext(Vote vote, PlayerVotes voteRecord, VoteStreak streakRecord, OfflinePlayer player) {
         this.vote = vote;
         this.voteRecord = voteRecord;
+        this.streakRecord = streakRecord;
         this.player = player;
     }
 
@@ -25,6 +28,10 @@ public class MessageContext {
         return voteRecord;
     }
 
+    public Optional<VoteStreak> getStreakRecord() {
+        return Optional.ofNullable(streakRecord);
+    }
+
     public Optional<OfflinePlayer> getPlayer() {
         return Optional.ofNullable(player);
     }
@@ -34,6 +41,7 @@ public class MessageContext {
         return "MessageContext{" +
                 "vote=" + vote +
                 ", voteRecord=" + voteRecord +
+                ", streakRecord=" + streakRecord +
                 ", player=" + player +
                 '}';
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/PlainStringMessage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/PlainStringMessage.java
@@ -1,6 +1,5 @@
 package io.minimum.minecraft.superbvote.configuration.message;
 
-import io.minimum.minecraft.superbvote.configuration.message.placeholder.PlaceholderProvider;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;

--- a/src/main/java/io/minimum/minecraft/superbvote/configuration/message/placeholder/SuperbVotePlaceholderProvider.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/configuration/message/placeholder/SuperbVotePlaceholderProvider.java
@@ -2,6 +2,7 @@ package io.minimum.minecraft.superbvote.configuration.message.placeholder;
 
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
 import io.minimum.minecraft.superbvote.votes.Vote;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
 
 public class SuperbVotePlaceholderProvider implements PlaceholderProvider {
     @Override
@@ -12,6 +13,17 @@ public class SuperbVotePlaceholderProvider implements PlaceholderProvider {
         if (context.getVote().isPresent()) {
             Vote vote = context.getVote().get();
             base = base.replace("%service%", vote.getServiceName());
+        }
+        if (context.getStreakRecord().isPresent()) {
+            VoteStreak voteStreak = context.getStreakRecord().get();
+            base = base.replace("%streak%", Integer.toString(voteStreak.getCount()))
+                    .replace("%streak_days%", Integer.toString(voteStreak.getDays()));
+            if (base.contains("%streak_today_services%")) {
+            	int votedToday = (int) voteStreak.getServices().values().stream()
+                        .filter(timeSince -> timeSince <= 86400)
+                        .count();
+                base = base.replace("%streak_today_services%", Integer.toString(votedToday));
+            }
         }
         return base;
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/signboard/TopPlayerSignUpdater.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/signboard/TopPlayerSignUpdater.java
@@ -8,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.SkullType;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Sign;
@@ -58,7 +57,7 @@ public class TopPlayerSignUpdater implements Runnable {
                         PlainStringMessage m = SuperbVote.getPlugin().getConfiguration().getTopPlayerSignsConfiguration().getSignText().get(i);
                         PlayerVotes pv = top.get(sign.getPosition() - 1);
                         worldSign.setLine(i, m.getWithOfflinePlayer(null,
-                                new MessageContext(null, pv, null)).replace("%num%", Integer.toString(sign.getPosition())));
+                                new MessageContext(null, pv, null, null)).replace("%num%", Integer.toString(sign.getPosition())));
                     }
                     for (int i = lines; i < 4; i++) {
                         worldSign.setLine(i, "");

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/ExtendedVoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/ExtendedVoteStorage.java
@@ -1,0 +1,14 @@
+package io.minimum.minecraft.superbvote.storage;
+
+import io.minimum.minecraft.superbvote.util.PlayerVotes;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public interface ExtendedVoteStorage extends VoteStorage {
+	VoteStreak getVoteStreak(UUID player, boolean required);
+
+	List<Map.Entry<PlayerVotes, VoteStreak>> getAllPlayersAndStreaksWithNoVotesToday(List<UUID> onlinePlayers);
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/ExtendedVoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/ExtendedVoteStorage.java
@@ -8,7 +8,7 @@ import java.util.Map;
 import java.util.UUID;
 
 public interface ExtendedVoteStorage extends VoteStorage {
-	VoteStreak getVoteStreak(UUID player, boolean required);
+    VoteStreak getVoteStreak(UUID player, boolean required);
 
-	List<Map.Entry<PlayerVotes, VoteStreak>> getAllPlayersAndStreaksWithNoVotesToday(List<UUID> onlinePlayers);
+    List<Map.Entry<PlayerVotes, VoteStreak>> getAllPlayersAndStreaksWithNoVotesToday(List<UUID> onlinePlayers);
 }

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/MysqlVoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/MysqlVoteStorage.java
@@ -78,9 +78,9 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
                     }
                 }
                 try (ResultSet t = connection.getMetaData().getTables(null, null, streaksTableName, null)) {
-                	if (!t.next()) {
-                		try (Statement statement = connection.createStatement()) {
-                		    statement.executeUpdate("CREATE TABLE " + streaksTableName + " (uuid VARCHAR(36) PRIMARY KEY NOT NULL, streak INT NOT NULL DEFAULT 1, days INT NOT " +
+                    if (!t.next()) {
+                        try (Statement statement = connection.createStatement()) {
+                            statement.executeUpdate("CREATE TABLE " + streaksTableName + " (uuid VARCHAR(36) PRIMARY KEY NOT NULL, streak INT NOT NULL DEFAULT 1, days INT NOT " +
                                     "NULL DEFAULT 1, last_day DATE NOT NULL DEFAULT CURRENT_DATE(), services TEXT NOT NULL DEFAULT '{}', " +
                                     "CHECK(JSON_VALID(services)))");
                             statement.executeUpdate("CREATE INDEX uuid_last_day_idx ON " + streaksTableName + " (uuid, last_day)");
@@ -130,8 +130,8 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
             }
 
             if (SuperbVote.getPlugin().getConfiguration().getStreaksConfiguration().isEnabled()) {
-            	VoteStreak currentStreak = getVoteStreak(vote.getUuid(), true);
-            	if (currentStreak.getCount() == 0 && currentStreak.getDays() == 0) {
+                VoteStreak currentStreak = getVoteStreak(vote.getUuid(), true);
+                if (currentStreak.getCount() == 0 && currentStreak.getDays() == 0) {
                     try (PreparedStatement statement = connection.prepareStatement("INSERT INTO " + streaksTableName + " (uuid, services) VALUES (?, JSON_SET('{}', ?, " +
                             "UNIX_TIMESTAMP())) ON DUPLICATE KEY UPDATE streak = 1, days = 1, services = JSON_SET('{}', ?, UNIX_TIMESTAMP()), last_day = CURRENT_DATE()")) {
                         statement.setString(1, vote.getUuid().toString());
@@ -141,7 +141,7 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
                         statement.executeUpdate();
                     }
                 }
-            	else {
+                else {
                     try (PreparedStatement statement = connection.prepareStatement("INSERT INTO " + streaksTableName + " (uuid, services) VALUES (?, JSON_SET('{}', ?, " +
                             "UNIX_TIMESTAMP())) ON DUPLICATE KEY UPDATE streak = streak + 1, days = days + LEAST(1, DATEDIFF(CURRENT_DATE(), last_day))," +
                             " services = JSON_SET(services, ?, UNIX_TIMESTAMP()), last_day = CURRENT_DATE()")) {
@@ -326,17 +326,17 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
 
     @Override
     public List<Map.Entry<PlayerVotes, VoteStreak>> getAllPlayersAndStreaksWithNoVotesToday(List<UUID> onlinePlayers) {
-    	Map<UUID, PlayerVotes> noVotes = getAllPlayersWithNoVotesToday(onlinePlayers).stream()
+        Map<UUID, PlayerVotes> noVotes = getAllPlayersWithNoVotesToday(onlinePlayers).stream()
                 .collect(Collectors.toMap(PlayerVotes::getUuid, p -> p));
-    	if (noVotes.isEmpty()) {
-    	    return ImmutableList.of();
+        if (noVotes.isEmpty()) {
+            return ImmutableList.of();
         }
 
-    	List<Map.Entry<PlayerVotes, VoteStreak>> result = new ArrayList<>();
+        List<Map.Entry<PlayerVotes, VoteStreak>> result = new ArrayList<>();
         try (Connection connection = dbPool.getConnection()) {
             String valueStatement = Joiner.on(", ").join(Collections.nCopies(noVotes.size(), "?"));
             try (PreparedStatement statement = connection.prepareStatement("SELECT uuid, streak, days FROM " + streaksTableName + " WHERE uuid IN (" + valueStatement + ")")) {
-            	List<PlayerVotes> noVotesList = new ArrayList<>(noVotes.values());
+                List<PlayerVotes> noVotesList = new ArrayList<>(noVotes.values());
                 for (int i = 0; i < noVotesList.size(); i++) {
                     statement.setString(i + 1, noVotesList.get(i).toString());
                 }
@@ -378,8 +378,8 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
                 statement.setString(1, player.toString());
                 try (ResultSet resultSet = statement.executeQuery()) {
                     if (resultSet.next()) {
-						int daysDifference = resultSet.getInt(3);
-						// e.g: last vote on 10/03 11 PM,
+                        int daysDifference = resultSet.getInt(3);
+                        // e.g: last vote on 10/03 11 PM,
                         //        on 10/04 -> 1 day difference, player will be able to vote at 11 PM, leaving him 1 hour to remember about it
                         //        on 10/05 -> 2 days difference, hasn't voted but can vote until 11:59 PM, total of 25 hours to think about voting
                         //        on 10/06 -> 3 days difference, hasn't voted, break the streak
@@ -388,7 +388,7 @@ public class MysqlVoteStorage implements ExtendedVoteStorage {
                             // reset vote streak
                             try (PreparedStatement resetStatement = connection.prepareStatement("UPDATE " + streaksTableName + " SET streak = 0, days = 0, services = '{}'" +
                                     " WHERE uuid = ?")) {
-                            	resetStatement.setString(1, player.toString());
+                                resetStatement.setString(1, player.toString());
                                 resetStatement.executeUpdate();
                             }
                             return new VoteStreak(player, 0, 0, Maps.newHashMap());

--- a/src/main/java/io/minimum/minecraft/superbvote/storage/VoteStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/VoteStorage.java
@@ -2,6 +2,7 @@ package io.minimum.minecraft.superbvote.storage;
 
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import io.minimum.minecraft.superbvote.votes.Vote;
+import io.minimum.minecraft.superbvote.votes.VoteStreak;
 
 import java.util.List;
 import java.util.UUID;
@@ -18,6 +19,13 @@ public interface VoteStorage {
     void clearVotes();
 
     PlayerVotes getVotes(UUID player);
+
+    default VoteStreak getVoteStreakIfSupported(UUID player, boolean required) {
+        if (this instanceof ExtendedVoteStorage) {
+        	return ((ExtendedVoteStorage) this).getVoteStreak(player, required);
+        }
+        return null;
+    }
 
     List<PlayerVotes> getTopVoters(int amount, int page);
 

--- a/src/main/java/io/minimum/minecraft/superbvote/util/cooldowns/CooldownHandler.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/util/cooldowns/CooldownHandler.java
@@ -2,6 +2,7 @@ package io.minimum.minecraft.superbvote.util.cooldowns;
 
 import com.google.common.base.Preconditions;
 import io.minimum.minecraft.superbvote.SuperbVote;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.concurrent.ConcurrentHashMap;
@@ -9,6 +10,7 @@ import java.util.concurrent.ConcurrentMap;
 
 public class CooldownHandler<T> {
     private final ConcurrentMap<T, LocalDateTime> cooldowns = new ConcurrentHashMap<>(32, 0.75f, 1);
+    @Getter
     private final int max;
 
     public CooldownHandler(int max) {

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/SuperbVoteListener.java
@@ -6,11 +6,11 @@ import io.minimum.minecraft.superbvote.commands.SuperbVoteCommand;
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
 import io.minimum.minecraft.superbvote.signboard.TopPlayerSignFetcher;
 import io.minimum.minecraft.superbvote.storage.MysqlVoteStorage;
+import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.BrokenNag;
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import io.minimum.minecraft.superbvote.votes.rewards.VoteReward;
 import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -21,6 +21,7 @@ import org.bukkit.event.server.PluginEnableEvent;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.logging.Level;
 
 public class SuperbVoteListener implements Listener {
@@ -38,12 +39,29 @@ public class SuperbVoteListener implements Listener {
                 worldName = op.getPlayer().getWorld().getName();
             }
 
-            PlayerVotes pvCurrent = SuperbVote.getPlugin().getVoteStorage().getVotes(op.getUniqueId());
+            VoteStorage voteStorage = SuperbVote.getPlugin().getVoteStorage();
+            VoteStreak voteStreak = voteStorage.getVoteStreakIfSupported(op.getUniqueId(), false);
+            PlayerVotes pvCurrent = voteStorage.getVotes(op.getUniqueId());
             PlayerVotes pv = new PlayerVotes(op.getUniqueId(), op.getName(), pvCurrent.getVotes() + 1, PlayerVotes.Type.FUTURE);
             Vote vote = new Vote(op.getName(), op.getUniqueId(), event.getVote().getServiceName(),
                     event.getVote().getAddress().equals(SuperbVoteCommand.FAKE_HOST_NAME_FOR_VOTE), worldName, new Date());
 
             if (!vote.isFakeVote()) {
+                if (SuperbVote.getPlugin().getConfiguration().getStreaksConfiguration().isSharedCooldownPerService()) {
+                    if (voteStreak == null) {
+                        // becomes a required value
+                        voteStreak = voteStorage.getVoteStreakIfSupported(op.getUniqueId(), true);
+                    }
+                    if (voteStreak != null && voteStreak.getServices().containsKey(vote.getServiceName())) {
+                        long difference = SuperbVote.getPlugin().getVoteServiceCooldown().getMax() - voteStreak.getServices().get(vote.getServiceName());
+                        if (difference > 0) {
+                            SuperbVote.getPlugin().getLogger().log(Level.WARNING, "Ignoring vote from " + vote.getName() + " (service: " +
+                                    vote.getServiceName() + ") due to [shared] service cooldown.");
+                            return;
+                        }
+                    }
+                }
+
                 if (SuperbVote.getPlugin().getVoteServiceCooldown().triggerCooldown(vote)) {
                     SuperbVote.getPlugin().getLogger().log(Level.WARNING, "Ignoring vote from " + vote.getName() + " (service: " +
                             vote.getServiceName() + ") due to service cooldown.");
@@ -51,15 +69,15 @@ public class SuperbVoteListener implements Listener {
                 }
             }
 
-            processVote(pv, vote, SuperbVote.getPlugin().getConfig().getBoolean("broadcast.enabled"),
+            processVote(pv, voteStreak, vote, SuperbVote.getPlugin().getConfig().getBoolean("broadcast.enabled"),
                     !op.isOnline() && SuperbVote.getPlugin().getConfiguration().requirePlayersOnline(),
                     false);
         });
     }
 
-    private void processVote(PlayerVotes pv, Vote vote, boolean broadcast, boolean queue, boolean wasQueued) {
+    private void processVote(PlayerVotes pv, VoteStreak voteStreak, Vote vote, boolean broadcast, boolean queue, boolean wasQueued) {
         List<VoteReward> bestRewards = SuperbVote.getPlugin().getConfiguration().getBestRewards(vote, pv);
-        MessageContext context = new MessageContext(vote, pv, Bukkit.getOfflinePlayer(vote.getUuid()));
+        MessageContext context = new MessageContext(vote, pv, voteStreak, Bukkit.getOfflinePlayer(vote.getUuid()));
         boolean canBroadcast = SuperbVote.getPlugin().getRecentVotesStorage().canBroadcast(vote.getUuid());
         SuperbVote.getPlugin().getRecentVotesStorage().updateLastVote(vote.getUuid());
 
@@ -115,11 +133,14 @@ public class SuperbVoteListener implements Listener {
             }
 
             // Process queued votes.
-            PlayerVotes pv = SuperbVote.getPlugin().getVoteStorage().getVotes(event.getPlayer().getUniqueId());
-            List<Vote> votes = SuperbVote.getPlugin().getQueuedVotes().getAndRemoveVotes(event.getPlayer().getUniqueId());
+            VoteStorage voteStorage = SuperbVote.getPlugin().getVoteStorage();
+            UUID playerUUID = event.getPlayer().getUniqueId();
+            PlayerVotes pv = voteStorage.getVotes(playerUUID);
+            VoteStreak voteStreak = voteStorage.getVoteStreakIfSupported(playerUUID, false);
+            List<Vote> votes = SuperbVote.getPlugin().getQueuedVotes().getAndRemoveVotes(playerUUID);
             if (!votes.isEmpty()) {
                 for (Vote vote : votes) {
-                    processVote(pv, vote, false, false, true);
+                    processVote(pv, voteStreak, vote, false, false, true);
                     pv = new PlayerVotes(pv.getUuid(), event.getPlayer().getName(),pv.getVotes() + 1, PlayerVotes.Type.CURRENT);
                 }
                 afterVoteProcessing();
@@ -129,7 +150,7 @@ public class SuperbVoteListener implements Listener {
             if (SuperbVote.getPlugin().getConfig().getBoolean("vote-reminder.on-join") &&
                     event.getPlayer().hasPermission("superbvote.notify") &&
                     !SuperbVote.getPlugin().getVoteStorage().hasVotedToday(event.getPlayer().getUniqueId())) {
-                MessageContext context = new MessageContext(null, pv, event.getPlayer());
+                MessageContext context = new MessageContext(null, pv, voteStreak, event.getPlayer());
                 SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(event.getPlayer(), context);
             }
         });

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/VoteReminder.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/VoteReminder.java
@@ -2,11 +2,14 @@ package io.minimum.minecraft.superbvote.votes;
 
 import io.minimum.minecraft.superbvote.SuperbVote;
 import io.minimum.minecraft.superbvote.configuration.message.MessageContext;
+import io.minimum.minecraft.superbvote.storage.ExtendedVoteStorage;
+import io.minimum.minecraft.superbvote.storage.VoteStorage;
 import io.minimum.minecraft.superbvote.util.PlayerVotes;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -14,12 +17,28 @@ public class VoteReminder implements Runnable {
     @Override
     public void run() {
         List<UUID> onlinePlayers = Bukkit.getOnlinePlayers().stream().filter(p -> p.hasPermission("superbvote.notify")).map(Player::getUniqueId).collect(Collectors.toList());
-        List<PlayerVotes> noVotes = SuperbVote.getPlugin().getVoteStorage().getAllPlayersWithNoVotesToday(onlinePlayers);
-        for (PlayerVotes pv : noVotes) {
-            Player player = Bukkit.getPlayer(pv.getUuid());
-            if (player != null) {
-                MessageContext context = new MessageContext(null, pv, player);
-                SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(player, context);
+
+        VoteStorage voteStorage = SuperbVote.getPlugin().getVoteStorage();
+        if (SuperbVote.getPlugin().getConfiguration().getStreaksConfiguration().isPlaceholdersEnabled() && voteStorage instanceof ExtendedVoteStorage) {
+            List<Map.Entry<PlayerVotes, VoteStreak>> noVotes = ((ExtendedVoteStorage) voteStorage).getAllPlayersAndStreaksWithNoVotesToday(onlinePlayers);
+            for (Map.Entry<PlayerVotes, VoteStreak> entry : noVotes) {
+                PlayerVotes pv = entry.getKey();
+                VoteStreak voteStreak = entry.getValue();
+
+                Player player = Bukkit.getPlayer(pv.getUuid());
+                if (player != null) {
+                    MessageContext context = new MessageContext(null, pv, voteStreak, player);
+                    SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(player, context);
+                }
+            }
+        } else {
+            List<PlayerVotes> noVotes = voteStorage.getAllPlayersWithNoVotesToday(onlinePlayers);
+            for (PlayerVotes pv : noVotes) {
+                Player player = Bukkit.getPlayer(pv.getUuid());
+                if (player != null) {
+                    MessageContext context = new MessageContext(null, pv, null, player);
+                    SuperbVote.getPlugin().getConfiguration().getReminderMessage().sendAsReminder(player, context);
+                }
             }
         }
     }

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/VoteStreak.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/VoteStreak.java
@@ -1,0 +1,13 @@
+package io.minimum.minecraft.superbvote.votes;
+
+import lombok.Data;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+public class VoteStreak {
+	private final UUID uuid;
+	private final int count, days;
+	private final Map<String, Long> services;
+}

--- a/src/main/java/io/minimum/minecraft/superbvote/votes/VoteStreak.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/votes/VoteStreak.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 @Data
 public class VoteStreak {
-	private final UUID uuid;
-	private final int count, days;
-	private final Map<String, Long> services;
+    private final UUID uuid;
+    private final int count, days;
+    private final Map<String, Long> services;
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,6 +14,7 @@ storage:
     password: topsecret
     database: superbvote
     table: votes
+    streaks-table: streaks
     read-only: false
 
 # General vote configuration.
@@ -24,6 +25,26 @@ votes:
 
   # Whether or not to treat fake votes as real votes
   process-fake-votes: true
+
+# Streaks configuration
+# Important: Streaks does not support JSON storage
+streaks:
+  enabled: false
+  # Fetch streaks almost everywhere to enable %streak%, %streak_days%, and %streak_today_services% placeholders
+  # outside of streak-related commands
+  enable-placeholders: true
+
+  # Use time of last vote from the database to combine with `votes.cooldown-per-service`
+  # Basically turn the `votes.cooldown-per-service` into a database-based cooldown instead of a memory-based one
+  shared-cooldown-per-service: true
+
+  command:
+    # note: will be disabled if streaks are disabled
+    enabled: true
+    use-json-text: false
+    text: |-
+      You currently hold a vote streak of %streak% (%streak_days% days), keep going!
+      You've voted on %streak_today_services% website(s) out of X today.
 
 # Rewards. This is the main section you will need to edit. Ordering is important.
 rewards:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,6 +11,9 @@ commands:
     aliases: [sv]
   vote:
     description: SuperbVote vote command.
+  votestreak:
+    description: SuperbVote vote streak command.
+    aliases: [vstreak]
 permissions:
   superbvote.notify:
     default: true


### PR DESCRIPTION
Add vote streaks as an optional feature, supporting only MySQL for storage.
- Add command `/votestreak` that displays the current streak, configurable like the `/vote` command.
- 3 new placeholders (`%streak%`, `%streak_days%`, and `%streak_today_services%`). They can be disabled in non-required places to prevent useless database requests.
- When a player votes, his streak increases and the day counter of the streak increases automatically.
- Services and their timestamps are stored in a JSON field in the database, `services`, allowing us to know on which websites the player has voted for during the past 24 hours. This list is also used by a new setting `shared-cooldown-per-service` : makes `cooldown-per-service` work on different servers using the same database.

Days and vote timestamp are based on the database's time.

Technical changes:
- Added a new database table
- Renamed VoteCommand.java to CommonCommand.java as it shares everything except a message and a boolean with the streak command.