### PR TITLE
Fix Java 11 compatibility

### DIFF
--- a/src/main/java/io/minimum/minecraft/superbvote/storage/QueuedVotesStorage.java
+++ b/src/main/java/io/minimum/minecraft/superbvote/storage/QueuedVotesStorage.java
@@ -3,6 +3,7 @@ package io.minimum.minecraft.superbvote.storage;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
 import io.minimum.minecraft.superbvote.votes.Vote;
 
@@ -20,7 +21,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 public class QueuedVotesStorage {
     private final Map<UUID, List<Vote>> queuedVotes = new ConcurrentHashMap<>(32, 0.75f, 2);
-    private final Gson gson = new Gson();
+    private final Gson gson = new GsonBuilder().setDateFormat("MMM d, yyyy h:mm:ss").create();
     private final File saveTo;
 
     public QueuedVotesStorage(File file) throws IOException {


### PR DESCRIPTION
The date format was slightly changed (_a comma was added after the year_) somewhere between Java 8 and 11, which introduced an issue when trying to read the `queued_votes.json` file. This crude fix fixes compatibility with all future* Java 11 upgrades by forcing a specified date format.

Fixes #100

*) Users that have already upgraded to Java 11 and deleted/fixed their `queued_votes.json` will have to delete or fix the file again after this update, hence me calling it a crude fix.